### PR TITLE
fix: correct payment status check in handlePaymentCallback to ensure accurate error handling for non-completed payments

### DIFF
--- a/src/services/payment.service.js
+++ b/src/services/payment.service.js
@@ -78,8 +78,8 @@ const handlePaymentCallback = async (orderCode, status) => {
       throw new ApiError(httpStatus.NOT_FOUND, 'Payment not found');
     }
     const paymentStatusResponse = await payOS.getPaymentLinkInformation(payment.orderCode);
-    if (paymentStatusResponse.status !== 'PENDING') {
-      throw new ApiError(httpStatus.BAD_REQUEST, 'Payment is not pending');
+    if (paymentStatusResponse.status === 'PENDING') {
+      throw new ApiError(httpStatus.BAD_REQUEST, 'Payment is not completed');
     }
 
     if (status === 'PAID') {


### PR DESCRIPTION
This pull request includes a small but important change in the `handlePaymentCallback` function of the `payment.service.js` file. The change updates the logic for handling payment status to ensure that the error message aligns with the expected payment state.

* [`src/services/payment.service.js`](diffhunk://#diff-1dbdab5179cca2de6a762d8a5c595f5e493764452956d7fc762653b5e0fd8269L81-R82): Modified the conditional check for `paymentStatusResponse.status` to handle the case where the status is `PENDING` and updated the error message to "Payment is not completed" for better clarity.